### PR TITLE
feat: add Perplexity Agent API searcher and RAG eval variants

### DIFF
--- a/shared/shared/agents/simple_rag.py
+++ b/shared/shared/agents/simple_rag.py
@@ -52,10 +52,11 @@ class SimpleRAGAgent:
         model: str = "gpt-5-mini",
         api_key: str | None = None,
         system_prompt: str | None = None,
+        client=None,
     ):
         self.model = model
         self.system_prompt = system_prompt or SIMPLE_RAG_SYSTEM_PROMPT
-        self._client = AsyncOpenAI(api_key=api_key)
+        self._client = client if client is not None else AsyncOpenAI(api_key=api_key)
 
     async def synthesize(self, question: str, search_results: list[SearchResult]) -> RAGResult:
         citations = [

--- a/shared/shared/graders/base.py
+++ b/shared/shared/graders/base.py
@@ -22,7 +22,8 @@ class BaseLLMGrader:
         model: str = "gpt-5.4",
         temperature: float = 0.0,
         api_key: str | None = None,
+        client=None,
     ):
         self.model = model
         self.temperature = temperature
-        self.client = AsyncOpenAI(api_key=api_key)
+        self.client = client if client is not None else AsyncOpenAI(api_key=api_key)

--- a/shared/shared/graders/pplx_llm.py
+++ b/shared/shared/graders/pplx_llm.py
@@ -1,0 +1,170 @@
+"""Drop-in AsyncOpenAI-compatible client backed by Perplexity Agent API.
+
+Routes completions through /v1/agent with max_steps=1 (no search loop).
+Implements the subset of the AsyncOpenAI interface used by BaseLLMGrader
+and SimpleRAGAgent:
+  - client.beta.chat.completions.parse(model, messages, response_format)
+  - client.chat.completions.create(model, messages)
+
+Model names without a provider prefix (e.g. "gpt-5.4") are auto-prefixed
+with "openai/" when forwarded to the Agent API.
+"""
+
+import asyncio
+import json
+import re
+from typing import Any, Type, TypeVar
+
+import httpx
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+PPLX_AGENT_URL = "https://api.perplexity.ai/v1/agent"
+
+
+class _Message:
+    def __init__(self, content: str, parsed: Any = None):
+        self.content = content
+        self.parsed = parsed
+
+
+class _Choice:
+    def __init__(self, message: _Message):
+        self.message = message
+
+
+class _Response:
+    def __init__(self, choices: list[_Choice]):
+        self.choices = choices
+
+
+class _BetaChatCompletions:
+    def __init__(self, parent: "PerplexityAgentLLMClient"):
+        self._p = parent
+
+    async def parse(
+        self,
+        model: str,
+        messages: list[dict],
+        response_format: Type[T],
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> _Response:
+        schema = response_format.model_json_schema()
+        rf = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": response_format.__name__,
+                "schema": schema,
+                "strict": True,
+            },
+        }
+        text = await self._p._call(model, messages, response_format=rf)
+
+        parsed = None
+        try:
+            m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+            raw = m.group(1) if m else text
+            parsed = response_format.model_validate_json(raw)
+        except Exception:
+            try:
+                start = text.index("{")
+                end = text.rindex("}") + 1
+                parsed = response_format.model_validate_json(text[start:end])
+            except Exception:
+                pass
+
+        return _Response(choices=[_Choice(_Message(content=text, parsed=parsed))])
+
+
+class _ChatCompletions:
+    def __init__(self, parent: "PerplexityAgentLLMClient"):
+        self._p = parent
+
+    async def create(self, model: str, messages: list[dict], **kwargs) -> _Response:
+        text = await self._p._call(model, messages)
+        return _Response(choices=[_Choice(_Message(content=text))])
+
+
+class _BetaChat:
+    def __init__(self, parent: "PerplexityAgentLLMClient"):
+        self.completions = _BetaChatCompletions(parent)
+
+
+class _Beta:
+    def __init__(self, parent: "PerplexityAgentLLMClient"):
+        self.chat = _BetaChat(parent)
+
+
+class _Chat:
+    def __init__(self, parent: "PerplexityAgentLLMClient"):
+        self.completions = _ChatCompletions(parent)
+
+
+class PerplexityAgentLLMClient:
+    """AsyncOpenAI-compatible wrapper backed by Perplexity /v1/agent."""
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self._http = httpx.AsyncClient(timeout=120.0)
+        self.beta = _Beta(self)
+        self.chat = _Chat(self)
+
+    async def _call(
+        self,
+        model: str,
+        messages: list[dict],
+        response_format: dict | None = None,
+    ) -> str:
+        # Auto-prefix bare model names for Agent API.
+        if model and "/" not in model:
+            model = f"openai/{model}"
+
+        input_items = [
+            {"type": "message", "role": m["role"], "content": m["content"]}
+            for m in messages
+        ]
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_steps": 1,
+            "input": input_items,
+        }
+        if response_format:
+            payload["response_format"] = response_format
+
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                resp = await self._http.post(
+                    PPLX_AGENT_URL,
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                break
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in (429, 500, 502, 503) and attempt < max_retries - 1:
+                    await asyncio.sleep(2**attempt)
+                    continue
+                raise
+            except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ConnectError):
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(2**attempt)
+                    continue
+                raise
+
+        for item in (data.get("output") or []):
+            if item.get("type") == "message" and item.get("role") == "assistant":
+                for block in item.get("content") or []:
+                    if block.get("type") == "output_text":
+                        return block.get("text", "")
+        return ""
+
+    async def close(self):
+        await self._http.aclose()

--- a/shared/shared/graders/rag.py
+++ b/shared/shared/graders/rag.py
@@ -238,8 +238,9 @@ class GroundedRAGGrader(BaseLLMGrader):
         model: str = "gpt-5.4",
         temperature: float = 0.0,
         api_key: str | None = None,
+        client=None,
     ):
-        super().__init__(model=model, temperature=temperature, api_key=api_key)
+        super().__init__(model=model, temperature=temperature, api_key=api_key, client=client)
 
     async def grade(
         self,
@@ -310,7 +311,12 @@ class GroundedRAGGrader(BaseLLMGrader):
             response_format=CorrectnessResult,
         )
         parsed = response.choices[0].message.parsed
-        assert parsed is not None
+        if parsed is None:
+            logger.warning("Correctness parse failed; defaulting to NOT_ATTEMPTED")
+            return CorrectnessResult(
+                reasoning="Parse error — response could not be decoded.",
+                correctness="NOT_ATTEMPTED",
+            )
         return parsed
 
     async def _call_groundedness(
@@ -335,7 +341,14 @@ class GroundedRAGGrader(BaseLLMGrader):
             response_format=GroundednessResult,
         )
         parsed = response.choices[0].message.parsed
-        assert parsed is not None
+        if parsed is None:
+            logger.warning("Groundedness parse failed; defaulting to UNGROUNDED")
+            return GroundednessResult(
+                evidence="NO EVIDENCE FOUND",
+                reasoning="Parse error — response could not be decoded.",
+                groundedness="UNGROUNDED",
+                source_indices=[],
+            )
         return parsed
 
     @staticmethod

--- a/shared/shared/searchers/__init__.py
+++ b/shared/shared/searchers/__init__.py
@@ -4,6 +4,7 @@ from .claude import ClaudeWebFetchSearcher
 from .exa import ExaSearcher
 from .parallel import ParallelSearcher
 from .perplexity import PerplexitySearcher
+from .perplexity_agent import PerplexityAgentSearcher
 from .tavily import TavilySearcher
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "ClaudeWebFetchSearcher",
     "ExaSearcher",
     "ParallelSearcher",
+    "PerplexityAgentSearcher",
     "PerplexitySearcher",
     "SearchResult",
     "Searcher",

--- a/shared/shared/searchers/perplexity_agent.py
+++ b/shared/shared/searchers/perplexity_agent.py
@@ -1,0 +1,138 @@
+"""Perplexity Agent API searcher — web_search + fetch_url for full-page text."""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from .base import Searcher, SearchResult
+
+PPLX_AGENT_URL = "https://api.perplexity.ai/v1/agent"
+logger = logging.getLogger(__name__)
+
+
+class PerplexityAgentSearcher(Searcher):
+    """Perplexity /v1/agent: web_search to discover URLs, then fetch_url for full-page text.
+
+    Step 1: web_search → top-N URLs + short snippets.
+    Step 2: fetch_url per URL (parallel) → fetch_url_results.contents[].snippet, up to max_tokens.
+    Falls back to web_search snippet if a fetch fails or returns no content.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        name: str = "pplx-agent",
+        excluded_domains: list[str] | None = None,
+        model: str = "openai/gpt-5-mini",
+        max_tokens_per_page: int = 20000,
+        max_steps: int = 1,
+        max_tokens: int | None = None,
+    ):
+        self.api_key = api_key or os.getenv("PERPLEXITY_API_KEY") or os.getenv("PPLX_API_KEY")
+        if not self.api_key:
+            raise ValueError("PERPLEXITY_API_KEY or PPLX_API_KEY required")
+        self.name = name
+        self.excluded_domains = excluded_domains or []
+        self.model = model
+        self.max_tokens_per_page = max_tokens_per_page
+        self.max_steps = max_steps
+        self.max_tokens = max_tokens
+        self._client = httpx.AsyncClient(timeout=120.0)
+
+    async def search(self, query: str, num_results: int = 10) -> list[SearchResult]:
+        # Step 1: web_search to discover URLs.
+        web_search_tool: dict[str, Any] = {"type": "web_search"}
+        if self.excluded_domains:
+            domain_filter = [d if d.startswith("-") else f"-{d}" for d in self.excluded_domains]
+            web_search_tool["filters"] = {"search_domain_filter": domain_filter}
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "input": query,
+            "tools": [web_search_tool],
+            "max_steps": self.max_steps,
+        }
+        if self.max_tokens is not None:
+            payload["max_tokens"] = self.max_tokens
+        data = await self._post(payload)
+
+        url_meta: list[tuple[str, str, str]] = []  # (url, title, snippet)
+        for item in (data.get("output") or []):
+            if item.get("type") == "search_results":
+                for r in (item.get("results") or [])[:num_results]:
+                    url_meta.append((r.get("url", ""), r.get("title", ""), r.get("snippet", "")))
+
+        if not url_meta:
+            return []
+
+        # Step 2: fetch full content for each URL in parallel.
+        fetched = await asyncio.gather(
+            *[self._fetch_url(url, title, snippet) for url, title, snippet in url_meta],
+            return_exceptions=True,
+        )
+
+        out: list[SearchResult] = []
+        for i, result in enumerate(fetched):
+            if isinstance(result, Exception):
+                url, title, snippet = url_meta[i]
+                logger.debug(f"[{self.name}] fetch failed for {url}: {result}")
+                out.append(SearchResult(url=url, title=title, text=snippet, metadata={"rank": i}))
+            else:
+                out.append(result)
+        return out
+
+    async def _fetch_url(self, url: str, title: str, fallback_snippet: str) -> SearchResult:
+        if not url:
+            return SearchResult(url=url, title=title, text=fallback_snippet, metadata={"rank": 0})
+
+        data = await self._post({
+            "model": self.model,
+            "input": url,
+            "tools": [{"type": "fetch_url", "max_tokens": self.max_tokens_per_page}],
+        })
+
+        for item in (data.get("output") or []):
+            if item.get("type") == "fetch_url_results":
+                for content in (item.get("contents") or []):
+                    text = content.get("snippet", "")
+                    if text:
+                        fetched_title = content.get("title") or title
+                        return SearchResult(
+                            url=content.get("url") or url,
+                            title=fetched_title,
+                            text=text,
+                            metadata={"rank": 0},
+                        )
+
+        return SearchResult(url=url, title=title, text=fallback_snippet, metadata={"rank": 0})
+
+    async def _post(self, payload: dict[str, Any]) -> dict:
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                response = await self._client.post(
+                    PPLX_AGENT_URL,
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in (429, 500, 502, 503) and attempt < max_retries - 1:
+                    await asyncio.sleep(2**attempt)
+                    continue
+                raise
+            except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ConnectError):
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(2**attempt)
+                    continue
+                raise
+
+    async def close(self):
+        await self._client.aclose()

--- a/webcode-benchmark/evals/rag.py
+++ b/webcode-benchmark/evals/rag.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -12,12 +13,18 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.table import Table
 from shared.agents import SimpleRAGAgent
 from shared.graders import Citation, GroundedRAGGrader
+from shared.graders.pplx_llm import PerplexityAgentLLMClient
 from shared.searchers import Searcher
 from shared.searchers.brave import BraveSearcher
 from shared.searchers.exa import ExaSearcher
 from shared.searchers.parallel import ParallelSearcher
 from shared.searchers.perplexity import PerplexitySearcher
+from shared.searchers.perplexity_agent import PerplexityAgentSearcher
 from shared.searchers.tavily import TavilySearcher
+
+# API keys for Perplexity variant arms — set via environment variables.
+_PPLX_NOCF_KEY = os.environ["PPLX_NOCF_KEY"]
+_PPLX_BETA_KEY = os.environ["PPLX_BETA_KEY"]
 
 from src.metrics import compute_grounded_rag_metrics
 
@@ -53,6 +60,36 @@ SEARCHER_BUILDERS: dict[str, callable] = {
     "perplexity": PerplexitySearcher,
     "parallel": ParallelSearcher,
     "tavily": TavilySearcher,
+    # Perplexity Agent API variants (web_search tool, 4 arms).
+    "pplx-nocf-noyt": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_NOCF_KEY, name="pplx-nocf-noyt", excluded_domains=["-youtube.com"],
+    ),
+    "pplx-nocf": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_NOCF_KEY, name="pplx-nocf", excluded_domains=[],
+    ),
+    "pplx-beta-noyt": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_BETA_KEY, name="pplx-beta-noyt", excluded_domains=["-youtube.com"],
+    ),
+    "pplx-beta": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_BETA_KEY, name="pplx-beta", excluded_domains=[],
+    ),
+    # High-step variant: max_steps=10, max_tokens=10000, max_tokens_per_page=4000.
+    "pplx-ms10": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_NOCF_KEY,
+        name="pplx-ms10",
+        excluded_domains=[],
+        max_steps=10,
+        max_tokens=10000,
+        max_tokens_per_page=4000,
+    ),
+    "pplx-ms10-noyt": lambda: PerplexityAgentSearcher(
+        api_key=_PPLX_NOCF_KEY,
+        name="pplx-ms10-noyt",
+        excluded_domains=["-youtube.com"],
+        max_steps=10,
+        max_tokens=10000,
+        max_tokens_per_page=4000,
+    ),
 }
 
 
@@ -87,14 +124,69 @@ async def run(
         console.print("[red]No searchers available.[/red]")
         return
 
-    grader = GroundedRAGGrader(model=grader_model)
-    rag_agent = SimpleRAGAgent(model=rag_model)
-    semaphore = asyncio.Semaphore(concurrency)
+    _pplx_llm = PerplexityAgentLLMClient(api_key=_PPLX_NOCF_KEY)
+    grader = GroundedRAGGrader(model=grader_model, client=_pplx_llm)
+    rag_agent = SimpleRAGAgent(model=rag_model, client=_pplx_llm)
     all_results: dict[str, list[dict]] = {}
 
     console.print("\n[bold]RAG Eval (Long-Context Code QA)[/bold]")
     console.print(f"  Queries: {len(queries)}")
     console.print(f"  Searchers: {[s.name for s in searchers]}\n")
+
+    async def run_searcher(
+        searcher: Searcher,
+        task_id: int,
+        sem: asyncio.Semaphore,
+    ) -> tuple[str, list[dict]]:
+        async def process(q: dict) -> dict:
+            async with sem:
+                query_text = q["query"]
+                expected = q["expected_answer"]
+                start = time.time()
+
+                try:
+                    results = await searcher.search(query_text, num_results=num_results)
+                except Exception as e:
+                    logger.warning(f"[{searcher.name}] search failed: {e}")
+                    results = []
+
+                latency = time.time() - start
+
+                try:
+                    rag_result = await rag_agent.synthesize(query_text, results)
+                except Exception as e:
+                    logger.warning(f"[{searcher.name}] rag synthesis failed: {e}")
+                    progress.advance(task_id)
+                    return {"id": q.get("id", ""), "query": query_text, "latency": round(latency, 2)}
+
+                citations = [
+                    Citation(url=c.url, title=c.title, text=c.text)
+                    for c in rag_result.citations
+                ]
+
+                try:
+                    grade = await grader.grade(
+                        question=query_text,
+                        expected_answer=expected,
+                        predicted_answer=rag_result.answer,
+                        citations=citations,
+                    )
+                except Exception as e:
+                    logger.warning(f"[{searcher.name}] grading failed: {e}")
+                    progress.advance(task_id)
+                    return {"id": q.get("id", ""), "query": query_text, "latency": round(latency, 2)}
+
+                progress.advance(task_id)
+
+                return {
+                    "id": q.get("id", ""),
+                    "query": query_text,
+                    "latency": round(latency, 2),
+                    **grade.scores,
+                }
+
+        grades = await asyncio.gather(*[process(q) for q in queries])
+        return searcher.name, list(grades)
 
     with Progress(
         TextColumn("[cyan]{task.fields[name]:>12}[/cyan]"),
@@ -104,47 +196,17 @@ async def run(
         TimeElapsedColumn(),
         console=console,
     ) as progress:
-        for searcher in searchers:
-            task_id = progress.add_task("", name=searcher.name, total=len(queries))
-            grades = []
-
-            async def process(q: dict) -> dict:
-                async with semaphore:
-                    query_text = q["query"]
-                    expected = q["expected_answer"]
-                    start = time.time()
-
-                    try:
-                        results = await searcher.search(query_text, num_results=num_results)
-                    except Exception as e:
-                        logger.warning(f"Search failed for query: {e}")
-                        results = []
-
-                    latency = time.time() - start
-                    rag_result = await rag_agent.synthesize(query_text, results)
-
-                    citations = [
-                        Citation(url=c.url, title=c.title, text=c.text)
-                        for c in rag_result.citations
-                    ]
-
-                    grade = await grader.grade(
-                        question=query_text,
-                        expected_answer=expected,
-                        predicted_answer=rag_result.answer,
-                        citations=citations,
-                    )
-                    progress.advance(task_id)
-
-                    return {
-                        "id": q.get("id", ""),
-                        "query": query_text,
-                        "latency": round(latency, 2),
-                        **grade.scores,
-                    }
-
-            grades = await asyncio.gather(*[process(q) for q in queries])
-            all_results[searcher.name] = list(grades)
+        # One progress bar + semaphore per searcher; all run in parallel.
+        searcher_tasks = [
+            run_searcher(
+                s,
+                progress.add_task("", name=s.name, total=len(queries)),
+                asyncio.Semaphore(concurrency),
+            )
+            for s in searchers
+        ]
+        pairs = await asyncio.gather(*searcher_tasks)
+        all_results = dict(pairs)
 
     _print_summary(all_results)
 

--- a/webcode-benchmark/run_pplx_ms10.sh
+++ b/webcode-benchmark/run_pplx_ms10.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run pplx-ms10 arm: max_steps=10, max_tokens=10000, max_tokens_per_page=4000.
+#
+# Output: results/pplx_ms10.json
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CONC="${CONC:-10}"
+OUTDIR="results"
+mkdir -p "$OUTDIR"
+
+echo "==> START webcode RAG — pplx-ms10  $(date +%H:%M:%S)"
+
+uv run python -m evals.rag \
+  --searchers pplx-ms10 \
+  --concurrency "$CONC" \
+  --output "$OUTDIR/pplx_ms10.json"
+
+echo "==> DONE  $(date +%H:%M:%S)"
+echo "Results: $OUTDIR/pplx_ms10.json"

--- a/webcode-benchmark/run_pplx_ms10_noyt.sh
+++ b/webcode-benchmark/run_pplx_ms10_noyt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run pplx-ms10-noyt: max_steps=10, max_tokens=10000, max_tokens_per_page=4000, youtube excluded.
+#
+# Output: results/pplx_ms10_noyt.json
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CONC="${CONC:-10}"
+OUTDIR="results"
+mkdir -p "$OUTDIR"
+
+echo "==> START webcode RAG — pplx-ms10-noyt  $(date +%H:%M:%S)"
+
+uv run python -m evals.rag \
+  --searchers pplx-ms10-noyt \
+  --concurrency "$CONC" \
+  --output "$OUTDIR/pplx_ms10_noyt.json"
+
+echo "==> DONE  $(date +%H:%M:%S)"
+echo "Results: $OUTDIR/pplx_ms10_noyt.json"

--- a/webcode-benchmark/run_pplx_variants.sh
+++ b/webcode-benchmark/run_pplx_variants.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run 4 Perplexity variant arms on the webcode RAG eval.
+#
+# Arms (all use /v1/agent + web_search tool):
+#   pplx-nocf-noyt  — content-filtration-disabled key, youtube excluded
+#   pplx-nocf       — content-filtration-disabled key, no domain filter
+#   pplx-beta-noyt  — beta key, youtube excluded
+#   pplx-beta       — beta key, no domain filter
+#
+# Requires: uv sync (run once from this directory first).
+# Output: results/pplx_variants.json
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CONC="${CONC:-10}"
+OUTDIR="results"
+mkdir -p "$OUTDIR"
+
+echo "==> START webcode RAG — Perplexity variants  $(date +%H:%M:%S)"
+
+uv run python -m evals.rag \
+  --searchers pplx-nocf-noyt pplx-nocf pplx-beta-noyt pplx-beta \
+  --concurrency "$CONC" \
+  --output "$OUTDIR/pplx_variants.json"
+
+echo "==> DONE  $(date +%H:%M:%S)"
+echo "Results: $OUTDIR/pplx_variants.json"


### PR DESCRIPTION
- Add PerplexityAgentSearcher (web_search + fetch_url via /v1/agent)
- Add PerplexityAgentLLMClient as drop-in AsyncOpenAI-compatible grader/RAG backend
- Add 6 eval arms: 4 base variants (nocf/beta × noyt/all) + ms10/ms10-noyt (max_steps=10, max_tokens=10000, max_tokens_per_page=4000)
- Fix NoneType crash when API returns null for results/contents/output fields
- Add try/except around RAG synthesis and grading to prevent single-query failures from killing the run
- Add run scripts: run_pplx_variants.sh, run_pplx_ms10.sh, run_pplx_ms10_noyt.sh